### PR TITLE
Update to new noaa consumer library

### DIFF
--- a/influxdbclient/influxdb_client.go
+++ b/influxdbclient/influxdb_client.go
@@ -197,9 +197,9 @@ func formatValues(points []Point) string {
 
 func formatTimestamp(points []Point) string {
 	if len(points) > 0 {
-		return strconv.FormatInt(points[0].Timestamp*1000*1000*1000, 10)
+		return strconv.FormatInt(points[0].Timestamp, 10)
 	} else {
-		return strconv.FormatInt(time.Now().Unix()*1000*1000*1000, 10)
+		return strconv.FormatInt(time.Now().Unix(), 10)
 	}
 }
 


### PR DESCRIPTION
Hello, 
    the noaa consumer library has updated and this project now complains about using a deprecated library.

Here is a pull request which implements the 2 commits from the upstream datadog nozzle to use the new library.  Not sure if it is easier to do this or pull selective commits from the upstream.

https://github.com/cloudfoundry-incubator/datadog-firehose-nozzle/commit/f329016f0bf4cb79b58ba7f6c9d6857cf6116ab9
https://github.com/cloudfoundry-incubator/datadog-firehose-nozzle/commit/74d4d0c948b2fff19287f677d2d25300f695b0bc